### PR TITLE
`importFromFileSystem` was failing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `importFromFileSystem` was failing to to missing `overwrite_corpus` paramter.
+
 ## [0.31.2] - 2022-09-28
 
 ### Fixed

--- a/src/main/java/org/corpus_tools/graphannis/CorpusStorageManager.java
+++ b/src/main/java/org/corpus_tools/graphannis/CorpusStorageManager.java
@@ -760,6 +760,8 @@ public class CorpusStorageManager implements AutoCloseable {
   /**
    * Import a corpus from an external location on the file system into this corpus storage.
    * 
+   * This will not overwrite an existing corpus.
+   * 
    * @param path The location on the file system where the corpus data is located.
    * @param format The format in which this corpus data is stored.
    * @param corpusName If not "null", override the name of the new corpus for file formats that
@@ -770,11 +772,29 @@ public class CorpusStorageManager implements AutoCloseable {
    */
   public void importFromFileSystem(String path, ImportFormat format, String corpusName,
       boolean diskBased) throws GraphANNISException {
+    importFromFileSystem(path, format, corpusName, diskBased, false);
+  }
+
+  /**
+   * Import a corpus from an external location on the file system into this corpus storage.
+   * 
+   * @param path The location on the file system where the corpus data is located.
+   * @param format The format in which this corpus data is stored.
+   * @param corpusName If not "null", override the name of the new corpus for file formats that
+   *        already provide a corpus name.
+   * @param diskBased If true, certain elements like the node annotation storage will be be
+   *        disk-based instead of using in-memory representations.
+   * @param overwriteExisting If true, overwrite a possible existing corpus.
+   * @throws GraphANNISException
+   */
+  public void importFromFileSystem(String path, ImportFormat format, String corpusName,
+      boolean diskBased, boolean overwriteExisting) throws GraphANNISException {
 
     checkNotClosed();
 
     AnnisErrorListRef err = new AnnisErrorListRef();
-    CAPI.annis_cs_import_from_fs(instance, path, format.capiVal, corpusName, diskBased, err);
+    CAPI.annis_cs_import_from_fs(instance, path, format.capiVal, corpusName, diskBased,
+        overwriteExisting, err);
     err.checkErrors();
 
   }

--- a/src/main/java/org/corpus_tools/graphannis/capi/CAPI.java
+++ b/src/main/java/org/corpus_tools/graphannis/capi/CAPI.java
@@ -220,7 +220,8 @@ public class CAPI implements Library {
       AnnisGraphUpdate update, AnnisErrorListRef err);
 
   public static native CharPointer annis_cs_import_from_fs(AnnisCorpusStorage cs, String path,
-      int format, String corpusName, boolean diskBased, AnnisErrorListRef err);
+      int format, String corpusName, boolean diskBased, boolean overwriteExisting,
+      AnnisErrorListRef err);
 
   public static native void annis_cs_export_to_fs(AnnisCorpusStorage cs,
       AnnisVec_AnnisCString corpusNames, String path, int format, AnnisErrorListRef err);


### PR DESCRIPTION
This was caused by the missing `overwrite_corpus` parameter in the C-API definition